### PR TITLE
10 stretch use argocd to deploy the GitHub runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,14 @@ You must have these tools installed to complete the setup:
 3. Wait for the operator to start ArgoCD. This may take a few minutes. You can monitor progress by looking at the Pods in the openshift-gitops project.
 4. Install applications using ArgoCD.
    * `oc create -f applications/`
-5. Install GitHub Runners.
-   * TBD
+5. Load secrets into vault by executing the following commands.
+```bash
+oc exec -n vault -it vault-0 -- vault kv put secret/github pat=<your-github-pat>
+oc exec -n vault -it vault-0 -- vault kv put secret/registry0 host=registry.access.redhat.com \
+   user=<your-username> password=<your-password>
+oc exec -n vault -it vault-0 -- vault kv put secret/registry1 host=quay.io \
+   user=<your-username> password=<your-password>
+```
 6. In the GitHub repository for the spring-petclinic example app, create or update the GitHub Actions secrets used by the ploigos workflow.
    * Browse to https://github.com/ploigos/spring-petclinic/settings/secrets/actions
    * Create or update these secrets:
@@ -24,7 +30,7 @@ You must have these tools installed to complete the setup:
      * *GITUSER* - The username that the PSR should use to clone and push to the workflow, application and -ops repos. This only needs to be updated when we create a new service account or fork the repo into a new organization. The value should be the username of a service account that was created within GitHub for this purpose.
      * *GITPASSWORD* - The password that the PSR should use to clone and push to the workflow, application and -ops repos. This only needs to be updated when we change the password in GitHub or start using a new service account. The value should be the password for a service account that was created within GitHub for this purpose.
 
-Note: 
+Note:
 > Run the spring-petclinic pipeline to ensure that everything works by navigating to the [application workflow page](https://github.com/ploigos/spring-petclinic/actions/workflows/main.yaml). Click on the Run workflow dropdown, leave the main branch selected, and select Run workflow.
 
 # Design

--- a/applications/github-runner-app.yaml
+++ b/applications/github-runner-app.yaml
@@ -31,28 +31,4 @@ spec:
       backoff:
         duration: 15s
 ---
-apiVersion: v1
-data:
-  token: cm9vdA==
-kind: Secret
-metadata:
-  name: vault-secret
-  namespace: github-runners
-type: Opaque
----
-apiVersion: external-secrets.io/v1beta1
-kind: SecretStore
-metadata:
-  name: vault-backend
-  namespace: github-runners
-spec:
-  provider:
-    vault:
-      server: "http://vault-internal.vault.svc.cluster.local:8200"
-      path: "secret"
-      version: "v2"
-      auth:
-        tokenSecretRef:
-          name: "vault-secret"
-          key: "token"
----
+

--- a/applications/github-runner-app.yaml
+++ b/applications/github-runner-app.yaml
@@ -1,0 +1,58 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: github-runners
+  namespace: devsecops
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/ploigos/openshift-actions-runner-chart
+    path: ./
+    targetRevision: main
+    helm:
+      valueFiles:
+        - values.yaml
+      parameters:
+        - name: replicas
+          value: "5"
+  destination:
+    server: "https://kubernetes.default.svc"
+    namespace: github-runners
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+    retry:
+      limit: 5 # number of failed sync attempt retries; unlimited number of attempts if less than 0
+      backoff:
+        duration: 15s
+---
+apiVersion: v1
+data:
+  token: cm9vdA==
+kind: Secret
+metadata:
+  name: vault-secret
+  namespace: github-runners
+type: Opaque
+---
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-backend
+  namespace: github-runners
+spec:
+  provider:
+    vault:
+      server: "http://vault-internal.vault.svc.cluster.local:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        tokenSecretRef:
+          name: "vault-secret"
+          key: "token"
+---

--- a/applications/vault-app.yaml
+++ b/applications/vault-app.yaml
@@ -39,3 +39,4 @@ spec:
       limit: 5 # number of failed sync attempt retries; unlimited number of attempts if less than 0
       backoff:
         duration: 15s # the amount to back off. Default unit is seconds, but could also be a duration (e.g. "2m", "1h")
+---


### PR DESCRIPTION
1. Updated README with manual seeding instructions
2. Created argo app to manage the openshift-runners chart deployment